### PR TITLE
docs: add badge documentation to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # agent-actions
 
+[![Agent Actions - Running](https://img.shields.io/badge/Agent_Actions-Running-blue?logo=github-actions&logoColor=white)](https://github.com/dwmkerr/agent-actions/actions/workflows/agent-actions.yml)
+
 Reusable GitHub Actions workflow for running AI agents (currently Claude Code) across repos. Define the agent configuration once here, call it from any repo with a thin workflow file.
 
 ## Quick Start


### PR DESCRIPTION
## Summary
- Add Badge section to README with shields.io badge template for repos using agent actions