### PR TITLE
docs: add agent identity section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,34 +48,19 @@ The caller workflow can override defaults:
 | `timeout_minutes` | `30` | Max runtime per invocation |
 | `allowed_users` | `dwmkerr` | Comma-separated GitHub usernames |
 
-## Important: Agent Identity
+## Agent Identity
 
-By default, the agent operates using the automatic `GITHUB_TOKEN` — which means commits and API calls appear as the **github-actions bot**, scoped to the triggering repo. It does _not_ run as your personal account, but it does have the permissions granted in the workflow (`contents: write`, `pull-requests: write`, `issues: write`).
+By default the agent uses the automatic `GITHUB_TOKEN` and appears as **github-actions bot**. To use a custom identity, pass `github_token`, `bot_name`, and `bot_id` — see [claude-code-action docs](https://github.com/anthropics/claude-code-action).
 
-To use a specific identity (e.g., a dedicated bot account), pass a Personal Access Token or GitHub App token as `github_token`, and set `bot_name`/`bot_id` to match:
+## Capabilities
 
-```yaml
-- uses: anthropics/claude-code-action@v1
-  with:
-    github_token: ${{ secrets.MY_BOT_PAT }}
-    bot_name: "my-bot"
-    bot_id: "12345678"
-```
-
-To limit scope, reduce the `permissions` block in the reusable workflow or use a fine-grained PAT with minimal permissions.
-
-## What the Agent Can Do
-
-- **Comment on issues and PRs** — respond to questions, explain code, suggest fixes
-- **Read and review pull requests** — analyze diffs, leave review comments, approve/request changes
-- **Push commits** — make code changes directly on branches
-
-See the [claude-code-action docs](https://github.com/anthropics/claude-code-action) for the full list of capabilities and configuration options.
+- Comment on issues and PRs, review code, suggest fixes
+- Read diffs, leave review comments, approve/request changes
+- Push commits directly on branches
 
 ## Examples
 
-- Create an issue with the `claude` label: [example issue](https://github.com/dwmkerr/agent-actions/issues/1)
-- Comment `@claude` on a PR: [demo PR](https://github.com/dwmkerr/agent-actions/pull/2) — try commenting `@claude describe the changes in this PR`
+- [Demo issue](https://github.com/dwmkerr/agent-actions/issues/8) — triggered by the `claude` label
 
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # agent-actions
 
-[![Agent Actions - Running](https://img.shields.io/badge/Agent_Actions-Running-blue?logo=github-actions&logoColor=white)](https://github.com/dwmkerr/agent-actions/actions/workflows/agent-actions.yml)
+[![Agent Actions - Running](https://img.shields.io/badge/Agent_Actions-Running-green?logo=github-actions&logoColor=white)](https://github.com/dwmkerr/agent-actions/actions/workflows/agent-actions.yml)
 
 Reusable GitHub Actions workflow for running AI agents (currently Claude Code) across repos. Define the agent configuration once here, call it from any repo with a thin workflow file.
 
@@ -15,7 +15,7 @@ Reusable GitHub Actions workflow for running AI agents (currently Claude Code) a
 Add this badge to your README to show that agent actions are configured:
 
 ```markdown
-[![Agent Actions - Running](https://img.shields.io/badge/Agent_Actions-Running-blue?logo=github-actions&logoColor=white)](https://github.com/{owner}/{repo}/actions/workflows/agent-actions.yml)
+[![Agent Actions - Running](https://img.shields.io/badge/Agent_Actions-Running-green?logo=github-actions&logoColor=white)](https://github.com/{owner}/{repo}/actions/workflows/agent-actions.yml)
 ```
 
 Replace `{owner}/{repo}` with your repository path.

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ By default the agent uses the automatic `GITHUB_TOKEN` and appears as **github-a
 
 ## Examples
 
-- [Demo issue](https://github.com/dwmkerr/agent-actions/issues/8) — triggered by the `claude` label
+- [Demo: bug fix](https://github.com/dwmkerr/agent-actions/issues/9) — agent triages a bug and opens a PR
 
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -64,10 +64,18 @@ To use a specific identity (e.g., a dedicated bot account), pass a Personal Acce
 
 To limit scope, reduce the `permissions` block in the reusable workflow or use a fine-grained PAT with minimal permissions.
 
+## What the Agent Can Do
+
+- **Comment on issues and PRs** — respond to questions, explain code, suggest fixes
+- **Read and review pull requests** — analyze diffs, leave review comments, approve/request changes
+- **Push commits** — make code changes directly on branches
+
+See the [claude-code-action docs](https://github.com/anthropics/claude-code-action) for the full list of capabilities and configuration options.
+
 ## Examples
 
 - Create an issue with the `claude` label: [example issue](https://github.com/dwmkerr/agent-actions/issues/1)
-- Comment `@claude` on a PR: [example PR](https://github.com/dwmkerr/agent-actions/pull/2)
+- Comment `@claude` on a PR: [demo PR](https://github.com/dwmkerr/agent-actions/pull/2) — try commenting `@claude describe the changes in this PR`
 
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -48,6 +48,22 @@ The caller workflow can override defaults:
 | `timeout_minutes` | `30` | Max runtime per invocation |
 | `allowed_users` | `dwmkerr` | Comma-separated GitHub usernames |
 
+## Important: Agent Identity
+
+By default, the agent operates using the automatic `GITHUB_TOKEN` — which means commits and API calls appear as the **github-actions bot**, scoped to the triggering repo. It does _not_ run as your personal account, but it does have the permissions granted in the workflow (`contents: write`, `pull-requests: write`, `issues: write`).
+
+To use a specific identity (e.g., a dedicated bot account), pass a Personal Access Token or GitHub App token as `github_token`, and set `bot_name`/`bot_id` to match:
+
+```yaml
+- uses: anthropics/claude-code-action@v1
+  with:
+    github_token: ${{ secrets.MY_BOT_PAT }}
+    bot_name: "my-bot"
+    bot_id: "12345678"
+```
+
+To limit scope, reduce the `permissions` block in the reusable workflow or use a fine-grained PAT with minimal permissions.
+
 ## Examples
 
 - Create an issue with the `claude` label: [example issue](https://github.com/dwmkerr/agent-actions/issues/1)


### PR DESCRIPTION
## Summary
- Add "Important: Agent Identity" section explaining default GitHub token behavior and how to configure a custom bot identity