### PR TITLE
fix: rename reserved github_token secret to bot_token

### DIFF
--- a/.github/workflows/agent-actions.yml
+++ b/.github/workflows/agent-actions.yml
@@ -19,4 +19,4 @@ jobs:
       bot_id: "246517607"
     secrets:
       anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-      github_token: ${{ secrets.DWMKERR_AGENT_TOKEN }}
+      bot_token: ${{ secrets.DWMKERR_AGENT_TOKEN }}

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -26,7 +26,7 @@ on:
     secrets:
       anthropic_api_key:
         required: true
-      github_token:
+      bot_token:
         description: "PAT for a custom bot identity. If unset, defaults to GITHUB_TOKEN (github-actions bot)"
         required: false
 
@@ -68,6 +68,6 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.anthropic_api_key }}
           trigger_phrase: ${{ inputs.trigger_phrase }}
-          github_token: ${{ secrets.github_token }}
+          github_token: ${{ secrets.bot_token }}
           bot_name: ${{ inputs.bot_name }}
           bot_id: ${{ inputs.bot_id }}

--- a/caller-template.yml
+++ b/caller-template.yml
@@ -18,7 +18,7 @@ jobs:
     secrets:
       anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
       # Optional: PAT for a custom bot identity (otherwise defaults to github-actions bot)
-      # github_token: ${{ secrets.MY_BOT_TOKEN }}
+      # bot_token: ${{ secrets.MY_BOT_TOKEN }}
     # Uncomment to override defaults:
     # with:
     #   trigger_phrase: "@claude"


### PR DESCRIPTION
## Summary
- `github_token` is a reserved secret name in reusable workflows and caused the workflow file to fail validation; rename to `bot_token`