### PR TITLE
chore: allow dwmkerr-agent to trigger workflow

### DIFF
--- a/.github/workflows/agent-actions.yml
+++ b/.github/workflows/agent-actions.yml
@@ -17,6 +17,7 @@ jobs:
     with:
       bot_name: "dwmkerr-agent"
       bot_id: "246517607"
+      allowed_users: "dwmkerr,dwmkerr-agent"
     secrets:
       anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
       bot_token: ${{ secrets.DWMKERR_AGENT_TOKEN }}


### PR DESCRIPTION
## Summary
- Add `dwmkerr-agent` to `allowed_users` so the bot identity can self-trigger for testing