### PR TITLE
fix: default bot_name/bot_id so git-config step doesn't fail on empty inputs

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -16,11 +16,11 @@ on:
         type: string
         default: "dwmkerr"
       bot_name:
-        description: "GitHub username the agent posts as (requires github_token secret)"
+        description: "GitHub username used for git commits (default: github-actions[bot])"
         type: string
         default: ""
       bot_id:
-        description: "GitHub numeric user ID matching bot_name (requires github_token secret)"
+        description: "GitHub numeric user ID matching bot_name (default: 41898282, the github-actions[bot] ID)"
         type: string
         default: ""
     secrets:
@@ -69,5 +69,13 @@ jobs:
           anthropic_api_key: ${{ secrets.anthropic_api_key }}
           trigger_phrase: ${{ inputs.trigger_phrase }}
           github_token: ${{ secrets.bot_token }}
-          bot_name: ${{ inputs.bot_name }}
-          bot_id: ${{ inputs.bot_id }}
+          # Fall back to the github-actions[bot] identity when the caller
+          # doesn't supply one. Empty strings get forwarded to the action
+          # and override its own defaults, which makes `git config user.name ""`
+          # fail at the configureGitAuth step. The `|| default` pattern means
+          # an unset caller input resolves to the fallback instead of "".
+          # 41898282 is the stable GitHub user ID for github-actions[bot];
+          # it's hardcoded because GitHub App installation tokens can't
+          # query the /user endpoint to resolve it at runtime (claude-code-action #534).
+          bot_name: ${{ inputs.bot_name || 'github-actions[bot]' }}
+          bot_id: ${{ inputs.bot_id || '41898282' }}


### PR DESCRIPTION
## Summary
- `claude.yml` was forwarding empty `bot_name`/`bot_id` to `anthropics/claude-code-action`, overriding its own defaults
- The action builds the git user directly from those inputs with no fallback ([`src/modes/tag/index.ts:88-93`](https://github.com/anthropics/claude-code-action/blob/main/src/modes/tag/index.ts#L88-L93)), so `git config user.name ""` exits 1 at the configureGitAuth step
- Fix: default to the github-actions[bot] identity via the `${{ inputs.x || 'default' }}` pattern so caller overrides still work
- Magic number `41898282` is documented inline — GitHub App installation tokens can't hit the `/user` endpoint to resolve bot IDs at runtime (same rationale as [claude-code-action #534](https://github.com/anthropics/claude-code-action/pull/534))

## How it was surfaced
First real execution of the action from a downstream repo ([dwmkerr/livedown#31](https://github.com/dwmkerr/livedown/pull/31), run [24522692354](https://github.com/dwmkerr/livedown/actions/runs/24522692354)) failed with:

```
Setting git user as ...
Failed to configure git authentication: 
41 |   await $`git config user.name "${botName}"`;
```

Previous runs were all `skipped` (if-guard didn't match), which masked the bug.

## Test plan
- [ ] Trigger `@claude` on an issue or PR in a repo using this workflow and confirm the git-config step no longer fails